### PR TITLE
adding background fetch option to atoms

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,5 +12,6 @@ module.exports = {
       },
     ],
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-non-null-assertion": "off"
   },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+dist-worker
 *.local
 
 # Editor directories and files

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@martel/ripple",
       "version": "0.5.1",
       "dependencies": {
+        "comlink": "^4.3.1",
         "haunted": ">=4.8.3",
         "idb": "^7.0.1"
       },
@@ -5316,6 +5317,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/comlink": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.1.tgz",
+      "integrity": "sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA=="
     },
     "node_modules/command-line-args": {
       "version": "5.2.1",
@@ -19615,6 +19621,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "comlink": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.1.tgz",
+      "integrity": "sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA=="
     },
     "command-line-args": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "main": "./dist/ripple.umd.js",
   "module": "./dist/ripple.es.js",
   "exports": {
-    ".": {
+    "worker": {
+      "import": "./dist-worker/worker.es.js",
+      "require": "./dist-worker/worker.umd.js"
+    },
+    "ripple": {
       "import": "./dist/ripple.es.js",
       "require": "./dist/ripple.umd.js"
     }
@@ -13,11 +17,16 @@
   "files": [
     "dist/ripple.es.js",
     "dist/ripple.umd.js",
+    "dist-worker/worker.es.js",
+    "dist-worker/worker.umd.js",
     "types/ripple"
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "npm run build:types && npm run build:lib && npm run build:worker",
+    "build:types": "tsc",
+    "build:lib": "vite build --config vite.config.ts",
+    "build:worker": "vite build --config vite.config.worker.ts",
     "preview": "vite preview",
     "lint": "eslint --fix src",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,md}\"",
@@ -27,8 +36,9 @@
     "preversion": "npm run build"
   },
   "dependencies": {
+    "comlink": ">=4.3.1",
     "haunted": ">=4.8.3",
-    "idb": "^7.0.1"
+    "idb": ">=7.0.1"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",

--- a/src/example/atoms/post.ts
+++ b/src/example/atoms/post.ts
@@ -8,7 +8,20 @@ export interface IPost {
 }
 
 export const postListLoadingAtom = atom(true)
-export const postListAtom = atomList<IPost>([], { storage: { key: 'recent', store: 'posts', type: 'indexeddb' } })
+export const postListAtom = atomList<IPost>([], {
+  storage: {
+    key: 'recent',
+    store: 'posts',
+    type: 'indexeddb',
+    backgroundFetch: {
+      url: 'http://jsonplaceholder.typicode.com/posts',
+      refetch: 2,
+      onFetch: (res) => {
+        console.log(res)
+      },
+    },
+  },
+})
 
 export const postListCountAtom = atomRef<number>((get) => {
   console.log('called postListCountAtom')

--- a/src/example/views/view-index.ts
+++ b/src/example/views/view-index.ts
@@ -4,7 +4,9 @@ import { showPostsAtom } from '../atoms/content'
 
 import '../elements/todo-list'
 
-initAtomStorage({ version: 1 }, ['posts'])
+initAtomStorage({ version: 1 }, ['posts'], async () => {
+  return (await import('../../ripple/worker?worker')).default
+})
 
 function ViewIndex() {
   const [showPosts] = useAtom(showPostsAtom)

--- a/src/ripple/background.ts
+++ b/src/ripple/background.ts
@@ -1,0 +1,43 @@
+import * as Comlink from 'comlink'
+
+export interface BackgroundRequestInit extends RequestInit {
+  refetch?: number
+}
+
+export interface BackgroundResponse<T = Record<string, any> | Array<any> | string> {
+  readonly headers: Record<string, any>
+  readonly ok: boolean
+  readonly redirected: boolean
+  readonly status: number
+  readonly statusText: string
+  readonly body?: T
+}
+
+export interface BackgroundFetch extends BackgroundRequestInit {
+  url: RequestInfo | URL
+  onFetch: (res: Response) => void
+}
+
+let background: any
+
+export const initWorker = (worker: () => Promise<new () => Worker>) => {
+  if (background) {
+    return
+  }
+
+  worker().then((BackgroundWorker) => {
+    background = Comlink.wrap(new BackgroundWorker())
+  })
+}
+
+export const backgroundFetch = (
+  input: RequestInfo | URL,
+  onFetch: (res: Response) => void,
+  init?: BackgroundRequestInit,
+) => {
+  background.fetch(input, Comlink.proxy(onFetch), init)
+}
+
+export const cancelBackgroundFetch = (input: RequestInfo | URL, init?: BackgroundRequestInit) => {
+  background.cancel(input, init)
+}

--- a/src/ripple/storage.ts
+++ b/src/ripple/storage.ts
@@ -1,4 +1,5 @@
 import { openDB, IDBPDatabase } from 'idb'
+import { BackgroundFetch } from './background'
 
 export type StorageType = 'local' | 'session' | 'indexeddb'
 export type StorageConfig = {
@@ -7,6 +8,7 @@ export type StorageConfig = {
   store?: string
   key?: string
   type?: StorageType
+  backgroundFetch?: BackgroundFetch
 }
 
 export type StorageConfigComplete = {
@@ -15,6 +17,7 @@ export type StorageConfigComplete = {
   store: string
   key: string
   type: StorageType
+  backgroundFetch?: BackgroundFetch
 }
 
 export class Storage {

--- a/src/ripple/worker.js
+++ b/src/ripple/worker.js
@@ -1,0 +1,64 @@
+import * as Comlink from 'comlink'
+
+const refetchable = new Map()
+
+const fetchId = (input, init) => {
+  const url = input.toString()
+  if (!init) {
+    return url
+  }
+
+  let id = url
+  for (const [key, value] of Object.entries(init).sort(([a], [b]) => a.localeCompare(b))) {
+    id = `${id}::${key}=${value.toString()}`
+  }
+  return id
+}
+
+setInterval(() => {
+  for (const [id, f] of refetchable) {
+    f.init = f.init || {}
+    const fetchedAt = f.fetchedAt || 0
+    const { refetch = 0, ..._init } = f.init
+    if (Date.now() - refetch > fetchedAt * 1000) {
+      f.fetchedAt = Date.now()
+      refetchable.set(id, f)
+      fetch(f.input, _init).then(async (res) => {
+        const headers = {}
+        for (const [key, value] of res.headers) {
+          headers[key] = value
+        }
+        const isJson = headers["content-type"]?.startsWith("application/json")
+        const body = isJson ? await res.json() : await res.text()
+        return f.onFetch({ headers, ok: res.ok, redirected: res.redirected, status: res.status, statusText: res.statusText, body })
+      })
+    }
+  }
+}, 1000)
+
+const background = {
+  cancel(input, init) {
+    const { refetch, ..._init } = init || {}
+    if (refetch) {
+      refetchable.delete(fetchId(input, _init))
+    }
+  },
+  fetch(input, onFetch, init) {
+    const { refetch, ..._init } = init || {}
+    if (refetch) {
+      refetchable.set(fetchId(input, _init), { input, init, onFetch, fetchedAt: 0 })
+    } else {
+      fetch(input, _init).then(async (res) => {
+        const headers = {}
+        for (const [key, value] of res.headers) {
+          headers[key] = value
+        }
+        const isJson = headers["content-type"]?.startsWith("application/json")
+        const body = isJson ? await res.json() : await res.text()
+        return onFetch({ headers, ok: res.ok, redirected: res.redirected, status: res.status, statusText: res.statusText, body })
+      })
+    }
+  },
+}
+
+Comlink.expose(background)

--- a/types/ripple/atom.d.ts
+++ b/types/ripple/atom.d.ts
@@ -1,4 +1,4 @@
-import { StorageConfig, StorageType } from './storage';
+import { Storage, StorageConfig, StorageType } from './storage';
 export declare enum Keys {
     Value = "=",
     ListValue = "==",
@@ -7,7 +7,7 @@ export declare enum Keys {
     Write = ">",
     Self = "."
 }
-export declare const initAtomStorage: (config: StorageConfig, stores?: string[]) => void;
+export declare const initAtomStorage: (config: StorageConfig, stores?: string[], worker?: (() => Promise<new () => Worker>) | undefined) => Storage;
 export declare const StorageId: unique symbol;
 export declare const InitId: unique symbol;
 export declare const ReconcileId: unique symbol;

--- a/types/ripple/background.d.ts
+++ b/types/ripple/background.d.ts
@@ -1,0 +1,18 @@
+export interface BackgroundRequestInit extends RequestInit {
+    refetch?: number;
+}
+export interface BackgroundResponse<T = Record<string, any> | Array<any> | string> {
+    readonly headers: Record<string, any>;
+    readonly ok: boolean;
+    readonly redirected: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly body?: T;
+}
+export interface BackgroundFetch extends BackgroundRequestInit {
+    url: RequestInfo | URL;
+    onFetch: (res: Response) => void;
+}
+export declare const initWorker: (worker: () => Promise<new () => Worker>) => void;
+export declare const backgroundFetch: (input: RequestInfo | URL, onFetch: (res: Response) => void, init?: BackgroundRequestInit | undefined) => void;
+export declare const cancelBackgroundFetch: (input: RequestInfo | URL, init?: BackgroundRequestInit | undefined) => void;

--- a/types/ripple/storage.d.ts
+++ b/types/ripple/storage.d.ts
@@ -1,4 +1,5 @@
 import { IDBPDatabase } from 'idb';
+import { BackgroundFetch } from './background';
 export declare type StorageType = 'local' | 'session' | 'indexeddb';
 export declare type StorageConfig = {
     name?: string;
@@ -6,6 +7,7 @@ export declare type StorageConfig = {
     store?: string;
     key?: string;
     type?: StorageType;
+    backgroundFetch?: BackgroundFetch;
 };
 export declare type StorageConfigComplete = {
     name: string;
@@ -13,6 +15,7 @@ export declare type StorageConfigComplete = {
     store: string;
     key: string;
     type: StorageType;
+    backgroundFetch?: BackgroundFetch;
 };
 export declare class Storage {
     static db: IDBPDatabase | null;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
           lib: {
             entry: resolve(__dirname, 'src/ripple/index.ts'),
             name: 'Ripple',
+            fileName: (format) => `ripple.${format}.js`,
           },
           rollupOptions: {
             external: ['haunted'],

--- a/vite.config.worker.ts
+++ b/vite.config.worker.ts
@@ -1,0 +1,14 @@
+import { resolve } from 'path'
+import { defineConfig } from 'vite'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/ripple/worker.js'),
+      name: 'Worker',
+      fileName: (format) => `worker.${format}.js`,
+    },
+    outDir: 'dist-worker',
+  },
+})


### PR DESCRIPTION
Adds handling for backroundFetch to atoms.
Include a prebuilt worker to import. `import BackgroundWorker from '@martel/ripple/worker?worker'`